### PR TITLE
Adding auto toggle so it doesnt automatically associate the EIP on boot

### DIFF
--- a/manifests/eip.pp
+++ b/manifests/eip.pp
@@ -9,19 +9,20 @@ class nubis::eip (
     }
 
     if $ensure == 'present' {
-        $directory_ensure   = 'directory'
         $file_ensure        = 'file'
-    }
-    else {
-        $directory_ensure   = 'absent'
+    } else {
         $file_enure         = 'absent'
     }
 
-    if $auto {
-        file { '/etc/nubis.d/eip-associate':
-            ensure  => link,
-            target  => '/usr/local/sbin/eip-associate',
-        }
+    if $auto == true {
+        $link_ensure        = 'present'
+    } else {
+        $link_ensure        = 'absent'
+    }
+
+    file { '/etc/nubis.d/eip-associate':
+        ensure  => $link_ensure,
+        target  => '/usr/local/sbin/eip-associate',
     }
 
     file { '/usr/local/sbin/eip-associate':

--- a/manifests/eip.pp
+++ b/manifests/eip.pp
@@ -1,6 +1,7 @@
 
 class nubis::eip (
-    $ensure     = present
+    $ensure     = present,
+    $auto       = true
 ){
 
     if ! ($ensure in ['present', 'absent']) {
@@ -16,12 +17,18 @@ class nubis::eip (
         $file_enure         = 'absent'
     }
 
-    file { '/etc/nubis.d/eip-associate':
+    if $auto {
+        file { '/etc/nubis.d/eip-associate':
+            ensure  => link,
+            target  => '/usr/local/sbin/eip-associate',
+        }
+    }
+
+    file { '/usr/local/sbin/eip-associate':
         ensure  => $file_ensure,
         owner   => root,
         group   => root,
         mode    => '0755',
         source  => 'puppet:///modules/nubis_eip/eip-associate',
     }
-
 }

--- a/manifests/eip.pp
+++ b/manifests/eip.pp
@@ -1,5 +1,5 @@
 
-class nubis::eip (
+class nubis_eip::eip (
     $ensure     = present,
     $auto       = true
 ){


### PR DESCRIPTION
You may not always want to automatically associate to the EIP on boot, such as when a service test fails or another misconfiguration is detected.

My use case Akamai FastDNS - if the service test fails I want to assume bad data. Bad data is poisonous in this case.

It defaults to automatically associate on boot.
