### PR TITLE
Remove code that is redundant

### DIFF
--- a/manifests/eip.pp
+++ b/manifests/eip.pp
@@ -15,15 +15,12 @@ class nubis_eip::eip (
         $file_enure         = 'absent'
     }
 
-    if $auto == true {
-        $link_ensure        = 'link'
-    } else {
-        $link_ensure        = 'absent'
-    }
-
-    file { "/etc/nubis.d/${order}-eip-associate":
-        ensure  => $link_ensure,
-        target  => '/usr/local/sbin/eip-associate',
+    if $auto {
+        file { "/etc/nubis.d/${order}-eip-associate":
+            ensure  => $link_ensure,
+            target  => '/usr/local/sbin/eip-associate',
+            require => File['/usr/local/sbin/eip-associate']
+        }
     }
 
     file { '/usr/local/sbin/eip-associate':

--- a/manifests/eip.pp
+++ b/manifests/eip.pp
@@ -17,7 +17,7 @@ class nubis_eip::eip (
 
     if $auto {
         file { "/etc/nubis.d/${order}-eip-associate":
-            ensure  => $link_ensure,
+            ensure  => link,
             target  => '/usr/local/sbin/eip-associate',
             require => File['/usr/local/sbin/eip-associate']
         }


### PR DESCRIPTION
Cleaning up an if statement and wrapping it around the file resource instead, we don't have to do `$auto == true` since its a boolean statement. Also added a dependency on the symlink resource, we don't want to just symlink something if the script does not exists
